### PR TITLE
di instance manager ignores call time parameters of array

### DIFF
--- a/src/Di.php
+++ b/src/Di.php
@@ -236,11 +236,9 @@ class Di implements DependencyInjectionInterface
                 array_pop($this->instanceContext);
                 return $im->getSharedInstanceWithParameters(null, [], $fastHash);
             }
-        }
-
-        if ($im->hasSharedInstance($name, $callParameters)) {
+        } elseif ($im->hasSharedInstance($name)) {
             array_pop($this->instanceContext);
-            return $im->getSharedInstance($name, $callParameters);
+            return $im->getSharedInstance($name);
         }
 
         $config   = $im->getConfig($name);

--- a/src/Di.php
+++ b/src/Di.php
@@ -229,7 +229,7 @@ class Di implements DependencyInjectionInterface
 
         $im = $this->instanceManager;
 
-    $callParameters = $this->getCallParameters($name, $params);
+        $callParameters = $this->getCallParameters($name, $params);
         if ($callParameters) {
             $fastHash = $im->hasSharedInstanceWithParameters($name, $callParameters, true);
             if ($fastHash) {

--- a/src/Di.php
+++ b/src/Di.php
@@ -229,12 +229,17 @@ class Di implements DependencyInjectionInterface
 
         $im = $this->instanceManager;
 
-        $callParameters = $this->getCallParameters($name, $params);
+    $callParameters = $this->getCallParameters($name, $params);
         if ($callParameters) {
             $fastHash = $im->hasSharedInstanceWithParameters($name, $callParameters, true);
             if ($fastHash) {
                 array_pop($this->instanceContext);
                 return $im->getSharedInstanceWithParameters(null, [], $fastHash);
+            }
+
+            if (!$this->definitions->hasClass($name) && $im->hasSharedInstance($name)) {
+                array_pop($this->instanceContext);
+                return $im->getSharedInstance($name);
             }
         } elseif ($im->hasSharedInstance($name)) {
             array_pop($this->instanceContext);

--- a/src/InstanceManager.php
+++ b/src/InstanceManager.php
@@ -503,7 +503,7 @@ class InstanceManager /* implements InstanceManagerInterface */
                     $hashValue .= $param . '|';
                     break;
                 case 'array':
-                    $hashValue .= 'Array|';
+                    $hashValue .= $this->createHashForValues($classOrAlias, $param);
                     break;
                 case 'resource':
                     $hashValue .= 'resource|';

--- a/src/InstanceManager.php
+++ b/src/InstanceManager.php
@@ -503,7 +503,7 @@ class InstanceManager /* implements InstanceManagerInterface */
                     $hashValue .= $param . '|';
                     break;
                 case 'array':
-                    $hashValue .= $this->createHashForValues($classOrAlias, $param);
+                    $hashValue .= $this->createHashForValues($classOrAlias, $param) . '|';
                     break;
                 case 'resource':
                     $hashValue .= 'resource|';

--- a/test/DiTest.php
+++ b/test/DiTest.php
@@ -983,7 +983,7 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $di->setDefinitionList(new DefinitionList(new Definition\ArrayDefinition($arrayDefinition)));
 
         $di->instanceManager()->addSharedInstance(new $sharedInstanceClass, $sharedInstanceClass);
-        $returnedC = $di->get($retrievedInstanceClass, ['params' => ['testxxx']]);
+        $returnedC = $di->get($retrievedInstanceClass, ['params' => ['test']]);
         $this->assertInstanceOf($retrievedInstanceClass, $returnedC);
     }
 

--- a/test/DiTest.php
+++ b/test/DiTest.php
@@ -982,9 +982,17 @@ class DiTest extends \PHPUnit_Framework_TestCase
         // This also disables scanning of class A.
         $di->setDefinitionList(new DefinitionList(new Definition\ArrayDefinition($arrayDefinition)));
 
-        $di->instanceManager()->addSharedInstance(new $sharedInstanceClass, $sharedInstanceClass);
+        //getSharedInstance drops call time parameters, thus addSharedInstance makes no sence
+        // and we can get a new instance with parameters
+        $di->instanceManager()->addSharedInstanceWithParameters(new $sharedInstanceClass, $sharedInstanceClass, ['params' => ['test']]);
+        $di->instanceManager()->addSharedInstanceWithParameters(new $sharedInstanceClass, $sharedInstanceClass, ['params' => ['alter']]);
         $returnedC = $di->get($retrievedInstanceClass, ['params' => ['test']]);
         $this->assertInstanceOf($retrievedInstanceClass, $returnedC);
+
+        $this->assertEquals(['test'], $returnedC->params);
+        $returnedAltC = $di->get($retrievedInstanceClass, ['params' => ['alter']]);
+        $this->assertNotSame($returnedC, $returnedAltC);
+        $this->assertEquals(['alter'], $returnedAltC->params);
     }
 
     public function testGetInstanceWithParamsHasSameNameAsDependencyParam()
@@ -1016,5 +1024,103 @@ class DiTest extends \PHPUnit_Framework_TestCase
 
         $di = new Di(null, null, $config);
         $this->assertCount(1, $di->get('ZendTest\Di\TestAsset\AggregatedParamClass')->aggregator->items);
+    }
+
+    /**
+     * constructor injection consultation
+     *
+     * @group 4714
+     * @group 6388
+     */
+    public function testResolveMethodParametersDifferentParams()
+    {
+        $config = [
+            'instance' => [
+                'preference' => [
+                    'ZendTest\\Di\\TestAsset\\ConstructorInjection\\A' => 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\E',
+                ],
+            ],
+        ];
+        $di = new Di(null, null, new Config($config));
+        $ref = new \ReflectionObject($di);
+        $method = $ref->getMethod('resolveMethodParameters');
+        $method->setAccessible(true);
+
+        $args = [
+            'ZendTest\\Di\\TestAsset\\ConstructorInjection\\B',
+            '__construct',
+            [],
+            null,
+            Di::METHOD_IS_CONSTRUCTOR,
+            true
+        ];
+        $res = $method->invokeArgs($di, $args);
+        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\E', $res[0], 'the first resolved parameter for constructor type preferenced');
+
+        //user provides params
+        $args = [
+            'ZendTest\\Di\\TestAsset\\ConstructorInjection\\B',
+            '__construct',
+            ['a' => 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\F'],
+            null,
+            Di::METHOD_IS_CONSTRUCTOR,
+            true
+        ];
+        $res = $method->invokeArgs($di, $args);
+        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', $res[0], 'the first resolved parameter user provided ');
+
+        //user provides alias name
+        $im = $di->instanceManager();
+        $im->addAlias('foo', 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', ['params' => ['p' => 'v1']]);
+        $im->addAlias('bar', 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', ['params' => ['p' => 'v2']]);
+
+        $args = [
+            'ZendTest\\Di\\TestAsset\\ConstructorInjection\\B',
+            '__construct',
+            ['a' => 'foo'],
+            null,
+            Di::METHOD_IS_CONSTRUCTOR,
+            true
+        ];
+        $res = $method->invokeArgs($di, $args);
+        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', $res[0], 'the first resolved parameter user provided with alias parameter');
+        $this->assertEquals('v1', $res[0]->params['p']);
+
+        $args = [
+            'ZendTest\\Di\\TestAsset\\ConstructorInjection\\B',
+            '__construct',
+            ['a' => 'bar'],
+            null,
+            Di::METHOD_IS_CONSTRUCTOR,
+            true
+        ];
+        $res = $method->invokeArgs($di, $args);
+        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', $res[0], 'the first resolved parameter user provided with alias parameter');
+        $this->assertEquals('v2', $res[0]->params['p']);
+    }
+
+    public function testAliasesWithDeffrentParams()
+    {
+        $config = [
+            'instance' => [
+                'preference' => [
+                    'ZendTest\\Di\\TestAsset\\ConstructorInjection\\A' => 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\E',
+                ],
+            ],
+        ];
+        $di = new Di(null, null, new Config($config));
+        $im = $di->instanceManager();
+        $im->addAlias('foo', 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', ['params' => ['p' => 'vfoo']]);
+        $im->addAlias('bar', 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', ['params' => ['p' => 'vbar']]);
+
+        $pref = $di->get('ZendTest\\Di\\TestAsset\\ConstructorInjection\\B');
+        $bFoo = $di->get('ZendTest\\Di\\TestAsset\\ConstructorInjection\\B', ['a' => 'foo']);
+        $bBar = $di->get('ZendTest\\Di\\TestAsset\\ConstructorInjection\\B', ['a' => 'bar']);
+        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\E', $pref->a);
+        $this->assertNotSame($pref->a, $bFoo->a);
+        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', $bFoo->a);
+        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', $bBar->a);
+        $this->assertEquals('vfoo', $bFoo->a->params['p']);
+        $this->assertEquals('vbar', $bBar->a->params['p']);
     }
 }

--- a/test/InstanceManagerTest.php
+++ b/test/InstanceManagerTest.php
@@ -81,4 +81,32 @@ class InstanceManagerTest extends TestCase
 
         $this->assertEquals($config, $im->getConfig('foo-alias'));
     }
+
+    public function testInstanceManagerCanPersistInstancesWithArrayParameters()
+    {
+        $im = new InstanceManager();
+        $obj1 = new TestAsset\BasicClass();
+        $obj2 = new TestAsset\BasicClass();
+        $obj3 = new TestAsset\BasicClass();
+
+        $im->addSharedInstance($obj1, 'foo');
+        $im->addSharedInstanceWithParameters($obj2, 'foo', ['foo' => ['bar']]);
+
+        $this->assertSame($obj1, $im->getSharedInstance('foo'));
+        $this->assertSame($obj2, $im->getSharedInstanceWithParameters('foo', ['foo' => ['bar']]));
+        $this->assertFalse($im->hasSharedInstanceWithParameters('foo', ['foo' => []]));
+
+        $im->addSharedInstanceWithParameters($obj3, 'foo', ['foo' => ['baz']]);
+
+        $this->assertSame($obj2, $im->getSharedInstanceWithParameters('foo', ['foo' => ['bar']]));
+        $this->assertSame($obj3, $im->getSharedInstanceWithParameters('foo', ['foo' => ['baz']]));
+    }
+
+    public function testInstanceManagerCanPersistInstanceWithArrayWithClosure()
+    {
+        $im = new InstanceManager();
+        $obj1 = new TestAsset\BasicClass();
+        $im->addSharedInstanceWithParameters($obj1, 'foo', ['foo' => [function () {}]]);
+        $this->assertSame($obj1, $im->getSharedInstanceWithParameters('foo', ['foo' => [function () {}]]));
+    }
 }

--- a/test/TestAsset/ConstructorInjection/E.php
+++ b/test/TestAsset/ConstructorInjection/E.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Di\TestAsset\ConstructorInjection;
+
+class E extends A
+{
+}

--- a/test/TestAsset/ConstructorInjection/F.php
+++ b/test/TestAsset/ConstructorInjection/F.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Di\TestAsset\ConstructorInjection;
+
+class F extends A
+{
+    public $params;
+
+    public function __construct(array $params = [])
+    {
+        $this->params = $params;
+    }
+}


### PR DESCRIPTION
resolve this
https://github.com/zendframework/zf2/issues/4714

InstanceManager::sharedInstancesWithParams with Hash based management ignores entries of array.