### PR TITLE
Add Generator Factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Service factory `Zend\Di\Container\GeneratorFactory`, to create a
+  `Zend\Di\CodeGenerator\InjectorGenerator` instance with Zend ServiceManager
 
 ### Changed
 
-- Nothing.
+- Added `getOutputDirectory` to `Zend\Di\CodeGenerator\GeneratorTrait`.
+
+- Added `getNamespace()` to `Zend\Di\CodeGenerator\InjectorGenerator`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,17 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- #31 Service factory `Zend\Di\Container\GeneratorFactory`, to create a
-  `Zend\Di\CodeGenerator\InjectorGenerator` instance with Zend ServiceManager
+- [#31](https://github.com/zendframework/zend-di/pull/31) adds the service
+  factory `Zend\Di\Container\GeneratorFactory` for creating a
+  `Zend\Di\CodeGenerator\InjectorGenerator` instance with zend-servicemanager.
 
 ### Changed
 
-- #31 Added `getOutputDirectory` to `Zend\Di\CodeGenerator\GeneratorTrait`.
+- [#31](https://github.com/zendframework/zend-di/pull/31) adds the method
+  `getOutputDirectory()` to `Zend\Di\CodeGenerator\GeneratorTrait`.
 
-- #31 Added `getNamespace()` to `Zend\Di\CodeGenerator\InjectorGenerator`.
+- [#31](https://github.com/zendframework/zend-di/pull/31) adds the method
+  `getNamespace()` to `Zend\Di\CodeGenerator\InjectorGenerator`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Service factory `Zend\Di\Container\GeneratorFactory`, to create a
+- #31 Service factory `Zend\Di\Container\GeneratorFactory`, to create a
   `Zend\Di\CodeGenerator\InjectorGenerator` instance with Zend ServiceManager
 
 ### Changed
 
-- Added `getOutputDirectory` to `Zend\Di\CodeGenerator\GeneratorTrait`.
+- #31 Added `getOutputDirectory` to `Zend\Di\CodeGenerator\GeneratorTrait`.
 
-- Added `getNamespace()` to `Zend\Di\CodeGenerator\InjectorGenerator`.
+- #31 Added `getNamespace()` to `Zend\Di\CodeGenerator\InjectorGenerator`.
 
 ### Deprecated
 

--- a/composer.lock
+++ b/composer.lock
@@ -436,29 +436,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.1.1",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -477,7 +483,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-30T18:51:59+00:00"
+            "time": "2017-11-27T17:38:31+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -528,16 +534,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
@@ -549,7 +555,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
@@ -587,20 +593,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.3",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d"
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
-                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
                 "shasum": ""
             },
             "require": {
@@ -609,14 +615,13 @@
                 "php": "^7.0",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0",
+                "phpunit/php-token-stream": "^2.0.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
                 "phpunit/phpunit": "^6.0"
             },
             "suggest": {
@@ -625,7 +630,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -640,7 +645,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -651,20 +656,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-03T13:47:33+00:00"
+            "time": "2017-12-06T09:29:45+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -698,7 +703,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -792,16 +797,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
@@ -837,20 +842,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-08-20T05:47:52+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.4.4",
+            "version": "6.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932"
+                "reference": "1b2f933d5775f9237369deaa2d2bfbf9d652be4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/562f7dc75d46510a4ed5d16189ae57fbe45a9932",
-                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1b2f933d5775f9237369deaa2d2bfbf9d652be4c",
+                "reference": "1b2f933d5775f9237369deaa2d2bfbf9d652be4c",
                 "shasum": ""
             },
             "require": {
@@ -864,12 +869,12 @@
                 "phar-io/version": "^1.0",
                 "php": "^7.0",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.2.2",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^4.0.3",
-                "sebastian/comparator": "^2.0.2",
+                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
@@ -895,7 +900,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.4.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -921,33 +926,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-08T11:26:09+00:00"
+            "time": "2017-12-10T08:06:19+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.4",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
+                "reference": "283b9f4f670e3a6fd6c4ff95c51a952eb5c75933"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/283b9f4f670e3a6fd6c4ff95c51a952eb5c75933",
+                "reference": "283b9f4f670e3a6fd6c4ff95c51a952eb5c75933",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
                 "php": "^7.0",
                 "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.0"
+                "sebastian/exporter": "^3.1"
             },
             "conflict": {
                 "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.5"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -955,7 +960,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -970,7 +975,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -980,7 +985,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-08-03T14:08:16+00:00"
+            "time": "2017-12-10T08:01:53+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1847,16 +1852,16 @@
         },
         {
             "name": "zendframework/zend-servicemanager",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-servicemanager.git",
-                "reference": "c3036efb81f71bfa36cc9962ee5d4474f36581d0"
+                "reference": "0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/c3036efb81f71bfa36cc9962ee5d4474f36581d0",
-                "reference": "c3036efb81f71bfa36cc9962ee5d4474f36581d0",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7",
+                "reference": "0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7",
                 "shasum": ""
             },
             "require": {
@@ -1888,7 +1893,7 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "3.3-dev",
-                    "dev-develop": "3.4-dev"
+                    "dev-develop": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1906,7 +1911,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2017-03-01T22:08:02+00:00"
+            "time": "2017-11-27T18:11:25+00:00"
         }
     ],
     "aliases": [],

--- a/docs/book/codegen.md
+++ b/docs/book/codegen.md
@@ -14,7 +14,7 @@ based on these results.
 > $ composer require zendframework/zend-code
 > ```
 
-# Generating an optimized injector
+## Generating an optimized injector
 
 The `Zend\Di\CodeGenerator\InjectorGenerator` class offers an implementation to
 generate an optimized injector based on the runtime configuration and a resolver
@@ -47,7 +47,7 @@ $scanner = new DirectoryScanner(__DIR__);
 $generator->generate($scanner->getClassNames());
 ```
 
-# MVC and Expressive integration
+## MVC and Expressive integration
 
 When you are using zend-di's `ConfigProvider` or MVC `Module`, you can
 obtain the generator instance from Zend ServiceManager:
@@ -56,7 +56,7 @@ obtain the generator instance from Zend ServiceManager:
 $generator = $serviceManager->get(\Zend\Di\CodeGenerator\InjectorGenerator::class);
 ```
 
-## AoT Config Options
+### AoT Config Options
 
 The service factory uses options in your `config` service, located in `['dependencies']['auto']['aot']`.
 If present this can be an associative array of options to create the code generator instance.

--- a/docs/book/codegen.md
+++ b/docs/book/codegen.md
@@ -49,8 +49,9 @@ $generator->generate($scanner->getClassNames());
 
 ## MVC and Expressive integration
 
-When you are using zend-di's `ConfigProvider` or MVC `Module`, you can
-obtain the generator instance from Zend ServiceManager:
+When you are using zend-di's `ConfigProvider` with Expressive or consuming the
+`Module` class via zend-mvc, you can obtain the generator instance from the
+service manager:
 
 ```php
 $generator = $serviceManager->get(\Zend\Di\CodeGenerator\InjectorGenerator::class);
@@ -58,20 +59,21 @@ $generator = $serviceManager->get(\Zend\Di\CodeGenerator\InjectorGenerator::clas
 
 ### AoT Config Options
 
-The service factory uses options in your `config` service, located in `['dependencies']['auto']['aot']`.
-If present this can be an associative array of options to create the code generator instance.
-This array respects the following keys (unknown keys are ignored):
+The service factory uses options in your `config` service, located under the key
+`dependencies.auto.aot`. This should be defined as an associative array of
+options for creating the code generator instance. This array respects the
+following keys (unknown keys are ignored):
 
-- `namespace`: This will be used as base namespace to prefix the namespace of the generated classes.
-  It will be passed to the constructor of `Zend\Di\CodeGenerator\InjectorGenerator`. The default value
-  is `Zend\Di\Generated` if this option is not provided.
+- `namespace`: This will be used as base namespace to prefix the namespace of
+  the generated classes.  It will be passed to the constructor of
+  `Zend\Di\CodeGenerator\InjectorGenerator`; the default value is
+  `Zend\Di\Generated`.
 
-- `directory`: The directory where the generated php files will be stored. If this value is not provided,
-  you have to set it with the generator's `setOutputDirectory()` method before calling `generate()`.
+- `directory`: The directory where the generated PHP files will be stored. If
+  this value is not provided, you will need to set it with the generator's
+  `setOutputDirectory()` method before calling `generate()`.
 
-Example:
-
-Below is an example for configuring the generator factory:
+Below is an example detailing configuration of the generator factory:
 
 ```php
 return [
@@ -85,4 +87,3 @@ return [
     ],
 ];
 ```
-

--- a/docs/book/codegen.md
+++ b/docs/book/codegen.md
@@ -46,3 +46,45 @@ You can also utilize `Zend\Code\Scanner` to scan your code for classes:
 $scanner = new DirectoryScanner(__DIR__);
 $generator->generate($scanner->getClassNames());
 ```
+
+## Mvc and Expressive integration
+
+When you are using zend-di's `ConfigProvider` or MVC `Module`, you can
+obtain the generator instance from Zend ServiceManager:
+
+```php
+$generator = $serviceManager->get(\Zend\Di\CodeGenerator\InjectorGenerator::class);
+```
+
+See the [Configration](config.md) chapter for available configuration options of this method.
+
+### AoT Config Options
+
+The service factory uses options in your `config` service, located in `['dependencies']['auto']['aot']`.
+If present this can be an associative array of options to create the code generator instance.
+This array respects the following keys (unknown keys are ignored):
+
+- `namespace`: This will be used as base namespace to prefix the namespace of the generated classes.
+  It will be passed to the constructor of `Zend\Di\CodeGenerator\InjectorGenerator`. The default value
+  is `Zend\Di\Generated` if this option is not provided.
+
+- `directory`: The directory where the generated php files will be stored. If this value is not provided,
+  you have to set it with the generator's `setOutputDirectory()` method before calling `generate()`.
+
+Example:
+
+Below is an example for configuring the generator factory:
+
+```php
+return [
+    'dependencies' => [
+        'auto' => [
+            'aot' => [
+                'namespace' => 'AppAoT\Generated',
+                'directory' => __DIR__ . '/../gen',
+            ],
+        ],
+    ],
+];
+```
+

--- a/docs/book/codegen.md
+++ b/docs/book/codegen.md
@@ -14,7 +14,7 @@ based on these results.
 > $ composer require zendframework/zend-code
 > ```
 
-## Generating an optimized injector
+# Generating an optimized injector
 
 The `Zend\Di\CodeGenerator\InjectorGenerator` class offers an implementation to
 generate an optimized injector based on the runtime configuration and a resolver
@@ -47,7 +47,7 @@ $scanner = new DirectoryScanner(__DIR__);
 $generator->generate($scanner->getClassNames());
 ```
 
-## Mvc and Expressive integration
+# MVC and Expressive integration
 
 When you are using zend-di's `ConfigProvider` or MVC `Module`, you can
 obtain the generator instance from Zend ServiceManager:
@@ -56,9 +56,7 @@ obtain the generator instance from Zend ServiceManager:
 $generator = $serviceManager->get(\Zend\Di\CodeGenerator\InjectorGenerator::class);
 ```
 
-See the [Configration](config.md) chapter for available configuration options of this method.
-
-### AoT Config Options
+## AoT Config Options
 
 The service factory uses options in your `config` service, located in `['dependencies']['auto']['aot']`.
 If present this can be an associative array of options to create the code generator instance.

--- a/docs/book/cookbook/aot-guide.md
+++ b/docs/book/cookbook/aot-guide.md
@@ -222,8 +222,8 @@ use Zend\Di\Config;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-// Define the source directories to scan for classes to generate
-// AoT factories for
+// Define the source directories to scan for classes for which
+// to generate AoT factories:
 $directories = [
     __DIR__ . '/../src/App/src',
 ];
@@ -236,8 +236,10 @@ $generator = $container->get(InjectorGenerator::class);
 $generator->generate($scanner->getClassNames());
 ```
 
-> __Note:__ Before version 3.1 of zend-di, there is no service factory
-> for the generator, so you had to create the instance manually:
+> ### Manually creating a generator instance
+>
+> Before version 3.1, no service factory existed for the generator. Below is an
+> example demonstrating manual creation of the generator:
 >
 > ```php
 > <?php

--- a/docs/book/cookbook/use-with-servicemanager.md
+++ b/docs/book/cookbook/use-with-servicemanager.md
@@ -49,6 +49,6 @@ return [
 
 ## Service Factory For AoT Code Generation
 
-zend-di also provides a factory for `Zend\Di\CodeGenerator\InjectorGenerator`. This factory
-(`Zend\Di\Container\GeneratorFactory`) is also auto registered by the `Module` and
-`ConfigProvider` classes for Zend MVC and Expressive.
+zend-di also provides a factory for `Zend\Di\CodeGenerator\InjectorGenerator`.
+This factory (`Zend\Di\Container\GeneratorFactory`) is also auto registered by
+the `Module` and `ConfigProvider` classes for zend-mvc and Expressive.

--- a/docs/book/cookbook/use-with-servicemanager.md
+++ b/docs/book/cookbook/use-with-servicemanager.md
@@ -35,3 +35,20 @@ You can also use it to create instances with zend-di using an IoC container
 use Zend\Di\Container\AutowireFactory;
 (new AutowireFactory())->__invoke($container, MyClassname::class);
 ```
+
+Or you can use it as factory in your service configuration directly:
+
+```php
+return [
+    'factories' => [
+        SomeClass::class => \Zend\Di\Container\AutowireFactory::class,
+    ],
+];
+```
+
+
+## Service Factory For AoT Code Generation
+
+zend-di also provides a factory for `Zend\Di\CodeGenerator\InjectorGenerator`. This factory
+(`Zend\Di\Container\GeneratorFactory`) is also auto registered by the `Module` and
+`ConfigProvider` classes for Zend MVC and Expressive.

--- a/src/CodeGenerator/GeneratorTrait.php
+++ b/src/CodeGenerator/GeneratorTrait.php
@@ -81,10 +81,7 @@ trait GeneratorTrait
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getOutputDirectory(): ?string
+    public function getOutputDirectory() : ?string
     {
         return $this->outputDirectory;
     }

--- a/src/CodeGenerator/GeneratorTrait.php
+++ b/src/CodeGenerator/GeneratorTrait.php
@@ -80,4 +80,12 @@ trait GeneratorTrait
 
         return $this;
     }
+
+    /**
+     * @return string
+     */
+    public function getOutputDirectory(): ?string
+    {
+        return $this->outputDirectory;
+    }
 }

--- a/src/CodeGenerator/InjectorGenerator.php
+++ b/src/CodeGenerator/InjectorGenerator.php
@@ -147,6 +147,14 @@ class InjectorGenerator
     }
 
     /**
+     * Returns the namespace this generator uses
+     */
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    /**
      * Generate the injector
      *
      * This will generate the injector and its factories into the output directory

--- a/src/CodeGenerator/InjectorGenerator.php
+++ b/src/CodeGenerator/InjectorGenerator.php
@@ -149,7 +149,7 @@ class InjectorGenerator
     /**
      * Returns the namespace this generator uses
      */
-    public function getNamespace(): string
+    public function getNamespace() : string
     {
         return $this->namespace;
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -34,7 +34,8 @@ class ConfigProvider
         return [
             'factories' => [
                 InjectorInterface::class => Container\InjectorFactory::class,
-                ConfigInterface::class => Container\ConfigFactory::class
+                ConfigInterface::class => Container\ConfigFactory::class,
+                CodeGenerator\InjectorGenerator::class => Container\GeneratorFactory::class,
             ],
             'abstract_factories' => [
                 Container\ServiceManager\AutowireFactory::class

--- a/src/Container/GeneratorFactory.php
+++ b/src/Container/GeneratorFactory.php
@@ -8,12 +8,38 @@
 namespace Zend\Di\Container;
 
 use Psr\Container\ContainerInterface;
+use Zend\Di\CodeGenerator\InjectorGenerator;
+use Zend\Di\ConfigInterface;
+use Zend\Di\Definition\RuntimeDefinition;
+use Zend\Di\Resolver\DependencyResolver;
 
 class GeneratorFactory
 {
+    private function getConfig(ContainerInterface $container)
+    {
+        if ($container->has(ConfigInterface::class)) {
+            return $container->get(ConfigInterface::class);
+        }
+
+        return (new ConfigFactory())->create($container);
+    }
+
     public function create(ContainerInterface $container)
     {
-        // TODO: Implement the factory
+        $config = $container->has('config') ? $container->get('config') : [];
+        $diConfig = $this->getConfig($container);
+        $aotConfig = $config['dependencies']['auto']['aot'] ?? [];
+        $resolver = new DependencyResolver(new RuntimeDefinition(), $diConfig);
+        $namespace = $aotConfig['namespace'] ?? null;
+
+        $resolver->setContainer($container);
+        $generator = new InjectorGenerator($diConfig, $resolver, $namespace);
+
+        if (isset($aotConfig['directory'])) {
+            $generator->setOutputDirectory($aotConfig['directory']);
+        }
+
+        return $generator;
     }
 
     public function __invoke(ContainerInterface $container)

--- a/src/Container/GeneratorFactory.php
+++ b/src/Container/GeneratorFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-di for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-di/blob/master/LICENSE.md New BSD License
  */
 
@@ -15,7 +15,7 @@ use Zend\Di\Resolver\DependencyResolver;
 
 class GeneratorFactory
 {
-    private function getConfig(ContainerInterface $container): ConfigInterface
+    private function getConfig(ContainerInterface $container) : ConfigInterface
     {
         if ($container->has(ConfigInterface::class)) {
             return $container->get(ConfigInterface::class);
@@ -24,7 +24,7 @@ class GeneratorFactory
         return (new ConfigFactory())->create($container);
     }
 
-    public function create(ContainerInterface $container): InjectorGenerator
+    public function create(ContainerInterface $container) : InjectorGenerator
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $diConfig = $this->getConfig($container);

--- a/src/Container/GeneratorFactory.php
+++ b/src/Container/GeneratorFactory.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-di for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-di/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Di\Container;
+
+use Psr\Container\ContainerInterface;
+
+class GeneratorFactory
+{
+    public function create(ContainerInterface $container)
+    {
+        // TODO: Implement the factory
+    }
+
+    public function __invoke(ContainerInterface $container)
+    {
+        return $this->create($container);
+    }
+}

--- a/src/Container/GeneratorFactory.php
+++ b/src/Container/GeneratorFactory.php
@@ -15,7 +15,7 @@ use Zend\Di\Resolver\DependencyResolver;
 
 class GeneratorFactory
 {
-    private function getConfig(ContainerInterface $container)
+    private function getConfig(ContainerInterface $container): ConfigInterface
     {
         if ($container->has(ConfigInterface::class)) {
             return $container->get(ConfigInterface::class);
@@ -24,7 +24,7 @@ class GeneratorFactory
         return (new ConfigFactory())->create($container);
     }
 
-    public function create(ContainerInterface $container)
+    public function create(ContainerInterface $container): InjectorGenerator
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $diConfig = $this->getConfig($container);
@@ -42,7 +42,7 @@ class GeneratorFactory
         return $generator;
     }
 
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): InjectorGenerator
     {
         return $this->create($container);
     }

--- a/src/Container/GeneratorFactory.php
+++ b/src/Container/GeneratorFactory.php
@@ -42,7 +42,7 @@ class GeneratorFactory
         return $generator;
     }
 
-    public function __invoke(ContainerInterface $container): InjectorGenerator
+    public function __invoke(ContainerInterface $container) : InjectorGenerator
     {
         return $this->create($container);
     }

--- a/test/CodeGenerator/InjectorGeneratorTest.php
+++ b/test/CodeGenerator/InjectorGeneratorTest.php
@@ -24,7 +24,7 @@ class InjectorGeneratorTest extends TestCase
 
     use GeneratorTestTrait;
 
-    public function testGenerateCreatesFiles()
+    public function testGenerateCreatesFiles() : void
     {
         $config = new Config();
         $resolver = new DependencyResolver(new RuntimeDefinition(), $config);
@@ -41,7 +41,7 @@ class InjectorGeneratorTest extends TestCase
         $this->assertFileExists($this->dir . '/autoload.php');
     }
 
-    public function testGeneratedInjectorIsValidCode()
+    public function testGeneratedInjectorIsValidCode() : void
     {
         // The namespace must be unique, Since we will attempt to load the
         // generated class
@@ -59,7 +59,7 @@ class InjectorGeneratorTest extends TestCase
         $this->assertTrue(class_exists($class, false));
     }
 
-    public function testSetCustomNamespace()
+    public function testSetCustomNamespace() : void
     {
         $expected = self::DEFAULT_NAMESPACE . uniqid();
         $config = new Config();

--- a/test/CodeGenerator/InjectorGeneratorTest.php
+++ b/test/CodeGenerator/InjectorGeneratorTest.php
@@ -58,4 +58,14 @@ class InjectorGeneratorTest extends TestCase
         include $this->dir . '/GeneratedInjector.php';
         $this->assertTrue(class_exists($class, false));
     }
+
+    public function testSetCustomNamespace()
+    {
+        $expected = self::DEFAULT_NAMESPACE . uniqid();
+        $config = new Config();
+        $resolver = new DependencyResolver(new RuntimeDefinition(), $config);
+        $generator = new InjectorGenerator($config, $resolver, $expected);
+
+        $this->assertEquals($expected, $generator->getNamespace());
+    }
 }

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -7,24 +7,24 @@
 
 namespace ZendTest\Di;
 
-use PHPUnit\Framework\TestCase;
-use Zend\Di\ConfigProvider;
 use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit\Framework\TestCase;
 use Zend\Di\CodeGenerator\InjectorGenerator;
-use Zend\Di\InjectorInterface;
 use Zend\Di\ConfigInterface;
+use Zend\Di\ConfigProvider;
+use Zend\Di\InjectorInterface;
 
 /**
  * @coversDefaultClass Zend\Di\Module
  */
 class ConfigProviderTest extends TestCase
 {
-    public function testInstanceIsInvokable(): void
+    public function testInstanceIsInvokable() : void
     {
         $this->assertInternalType(IsType::TYPE_CALLABLE, new ConfigProvider());
     }
 
-    public function testProvidesDependencies(): void
+    public function testProvidesDependencies() : void
     {
         $provider = new ConfigProvider();
         $result = $provider();
@@ -36,22 +36,20 @@ class ConfigProviderTest extends TestCase
     /**
      * Provides service names that should be defined with a factory
      */
-    public function provideExpectedServicesWithFactory(): iterable
+    public function provideExpectedServicesWithFactory() : iterable
     {
         return [
             //               service name
-            'injector'  => [ InjectorInterface::class ],
-            'config'    => [ ConfigInterface::class ],
-            'generator' => [ InjectorGenerator::class ],
+            'injector'  => [InjectorInterface::class],
+            'config'    => [ConfigInterface::class],
+            'generator' => [InjectorGenerator::class],
         ];
     }
 
     /**
-     * Test if a service is provided by factory definition
-     *
      * @dataProvider provideExpectedServicesWithFactory
      */
-    public function testProvidesFactoryDefinition(string $serviceName): void
+    public function testProvidesFactoryDefinition(string $serviceName) : void
     {
         $result = (new ConfigProvider())->getDependencyConfig();
         $this->assertArrayHasKey($serviceName, $result['factories']);

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -10,23 +10,50 @@ namespace ZendTest\Di;
 use PHPUnit\Framework\TestCase;
 use Zend\Di\ConfigProvider;
 use PHPUnit\Framework\Constraint\IsType;
+use Zend\Di\CodeGenerator\InjectorGenerator;
+use Zend\Di\InjectorInterface;
+use Zend\Di\ConfigInterface;
 
 /**
  * @coversDefaultClass Zend\Di\Module
  */
 class ConfigProviderTest extends TestCase
 {
-    public function testInstanceIsInvokable()
+    public function testInstanceIsInvokable(): void
     {
         $this->assertInternalType(IsType::TYPE_CALLABLE, new ConfigProvider());
     }
 
-    public function testProvidesDependencies()
+    public function testProvidesDependencies(): void
     {
         $provider = new ConfigProvider();
         $result = $provider();
 
         $this->assertArrayHasKey('dependencies', $result);
         $this->assertEquals($provider->getDependencyConfig(), $result['dependencies']);
+    }
+
+    /**
+     * Provides service names that should be defined with a factory
+     */
+    public function provideExpectedServicesWithFactory(): iterable
+    {
+        return [
+            //               service name
+            'injector'  => [ InjectorInterface::class ],
+            'config'    => [ ConfigInterface::class ],
+            'generator' => [ InjectorGenerator::class ],
+        ];
+    }
+
+    /**
+     * Test if a service is provided by factory definition
+     *
+     * @dataProvider provideExpectedServicesWithFactory
+     */
+    public function testProvidesFactoryDefinition(string $serviceName): void
+    {
+        $result = (new ConfigProvider())->getDependencyConfig();
+        $this->assertArrayHasKey($serviceName, $result['factories']);
     }
 }

--- a/test/Container/GeneratorFactoryTest.php
+++ b/test/Container/GeneratorFactoryTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-di for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-di/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Di\Container;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Zend\Di\InjectorInterface;
+use Zend\Di\Injector;
+use Zend\Di\Container\GeneratorFactory;
+use Zend\Di\CodeGenerator\InjectorGenerator;
+use Zend\Di\ConfigInterface;
+use Zend\Di\Config;
+
+/**
+ * @covers Zend\Di\Container\GeneratorFactory
+ *
+ */
+class GeneratorFactoryTest extends TestCase
+{
+    public function testInvokeCreatesGenerator()
+    {
+        $injector = new Injector();
+        $factory = new GeneratorFactory();
+
+        $result = $factory($injector->getContainer());
+        $this->assertInstanceOf(InjectorGenerator::class, $result);
+    }
+
+    public function testFactoryUsesServicesFromContainer()
+    {
+        $container = $this->getMockBuilder(ContainerInterface::class)->getMockForAbstractClass();
+        $container->expects($this->atLeastOnce())
+            ->method('has')
+            ->with(InjectorInterface::class)
+            ->willReturn(true);
+
+        $container->expects($this->atLeastOnce())
+            ->method('has')
+            ->with(ConfigInterface::class)
+            ->willReturn(true);
+
+        $container->method('has')->willReturn(false);
+
+        $container->expects($this->atLeastOnce())
+            ->method('get')
+            ->with(InjectorInterface::class)
+            ->willReturn(new Injector());
+
+        $container->expects($this->atLeastOnce())
+            ->method('get')
+            ->with(ConfigInterface::class)
+            ->willReturn(new Config());
+
+        $factory = new GeneratorFactory();
+        $factory($container);
+    }
+}

--- a/test/Container/GeneratorFactoryTest.php
+++ b/test/Container/GeneratorFactoryTest.php
@@ -98,6 +98,7 @@ class GeneratorFactoryTest extends TestCase
             ->method('create')
             ->with($container);
 
-        $mock($container);
+        $result = $mock($container);
+        $this->assertInstanceOf(InjectorGenerator::class, $result);
     }
 }

--- a/test/Container/GeneratorFactoryTest.php
+++ b/test/Container/GeneratorFactoryTest.php
@@ -31,30 +31,35 @@ class GeneratorFactoryTest extends TestCase
         $this->assertInstanceOf(InjectorGenerator::class, $result);
     }
 
-    public function testFactoryUsesServicesFromContainer()
+    /**
+     * Data provider for testFactoryUsesServiceFromContainer
+     */
+    public function provideContainerServices()
+    {
+        return [
+            //              serviceName, provided instance
+            'config'    => [ConfigInterface::class,     new Config()],
+            'injector'  => [InjectorInterface::class,   new Injector()]
+        ];
+    }
+
+    /**
+     * @dataProvider provideContainerServices
+     */
+    public function testFactoryUsesServiceFromContainer(string $serviceName, $instance): void
     {
         $container = $this->getMockBuilder(ContainerInterface::class)->getMockForAbstractClass();
         $container->expects($this->atLeastOnce())
             ->method('has')
-            ->with(InjectorInterface::class)
-            ->willReturn(true);
-
-        $container->expects($this->atLeastOnce())
-            ->method('has')
-            ->with(ConfigInterface::class)
+            ->with($serviceName)
             ->willReturn(true);
 
         $container->method('has')->willReturn(false);
 
         $container->expects($this->atLeastOnce())
             ->method('get')
-            ->with(InjectorInterface::class)
-            ->willReturn(new Injector());
-
-        $container->expects($this->atLeastOnce())
-            ->method('get')
-            ->with(ConfigInterface::class)
-            ->willReturn(new Config());
+            ->with($serviceName)
+            ->willReturn($instance);
 
         $factory = new GeneratorFactory();
         $factory($container);

--- a/test/Container/GeneratorFactoryTest.php
+++ b/test/Container/GeneratorFactoryTest.php
@@ -84,4 +84,21 @@ class GeneratorFactoryTest extends TestCase
         $generator = (new GeneratorFactory())->create($container);
         $this->assertEquals($expected, $generator->getNamespace());
     }
+
+    public function testInvokeCallsCreate()
+    {
+        $mock = $this->getMockBuilder(GeneratorFactory::class)
+            ->setMethods(['create'])
+            ->enableProxyingToOriginalMethods()
+            ->getMock();
+
+        $container = $this->getMockBuilder(ContainerInterface::class)
+            ->getMockForAbstractClass();
+
+        $mock->expects($this->once())
+            ->method('create')
+            ->with($container);
+
+        $mock($container);
+    }
 }

--- a/test/Container/GeneratorFactoryTest.php
+++ b/test/Container/GeneratorFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-di for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-di/blob/master/LICENSE.md New BSD License
  */
 
@@ -19,11 +19,10 @@ use Zend\ServiceManager\ServiceManager;
 
 /**
  * @covers Zend\Di\Container\GeneratorFactory
- *
  */
 class GeneratorFactoryTest extends TestCase
 {
-    public function testInvokeCreatesGenerator()
+    public function testInvokeCreatesGenerator() : void
     {
         $injector = new Injector();
         $factory = new GeneratorFactory();
@@ -32,11 +31,11 @@ class GeneratorFactoryTest extends TestCase
         $this->assertInstanceOf(InjectorGenerator::class, $result);
     }
 
-    public function testFactoryUsesDiConfigContainer(): void
+    public function testFactoryUsesDiConfigContainer() : void
     {
         $container = $this->getMockBuilder(ContainerInterface::class)->getMockForAbstractClass();
         $container->method('has')->willReturnCallback(function ($type) {
-            return ($type == ConfigInterface::class);
+            return $type == ConfigInterface::class;
         });
 
         $container->expects($this->atLeastOnce())
@@ -48,7 +47,7 @@ class GeneratorFactoryTest extends TestCase
         $factory->create($container);
     }
 
-    public function testSetsOutputDirectoryFromConfig()
+    public function testSetsOutputDirectoryFromConfig() : void
     {
         $vfs = vfsStream::setup(uniqid('zend-di'));
         $expected = $vfs->url();
@@ -57,7 +56,7 @@ class GeneratorFactoryTest extends TestCase
             'dependencies' => [
                 'auto' => [
                     'aot' => [
-                        'directory' => $expected
+                        'directory' => $expected,
                     ],
                 ],
             ],
@@ -67,7 +66,7 @@ class GeneratorFactoryTest extends TestCase
         $this->assertEquals($expected, $generator->getOutputDirectory());
     }
 
-    public function testSetsNamespaceFromConfig()
+    public function testSetsNamespaceFromConfig() : void
     {
         $expected = 'ZendTest\\Di\\' . uniqid('Generated');
         $container = new ServiceManager();
@@ -85,7 +84,7 @@ class GeneratorFactoryTest extends TestCase
         $this->assertEquals($expected, $generator->getNamespace());
     }
 
-    public function testInvokeCallsCreate()
+    public function testInvokeCallsCreate() : void
     {
         $mock = $this->getMockBuilder(GeneratorFactory::class)
             ->setMethods(['create'])

--- a/test/Container/GeneratorFactoryTest.php
+++ b/test/Container/GeneratorFactoryTest.php
@@ -9,12 +9,12 @@ namespace ZendTest\Di\Container;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Zend\Di\InjectorInterface;
-use Zend\Di\Injector;
-use Zend\Di\Container\GeneratorFactory;
 use Zend\Di\CodeGenerator\InjectorGenerator;
-use Zend\Di\ConfigInterface;
 use Zend\Di\Config;
+use Zend\Di\ConfigInterface;
+use Zend\Di\Container\GeneratorFactory;
+use Zend\Di\Injector;
+use Zend\Di\InjectorInterface;
 
 /**
  * @covers Zend\Di\Container\GeneratorFactory


### PR DESCRIPTION
This PR provides service factories for the AoT code generators, to minimize repetetive Tasks when using AoT.

The factory should will the `config` service to obtain information such as target namespace and output directory.

As Stated in #30, component consumers will then be able to retrieve the generator from the IoC container:

```php
/** @var \Zend\ServiceManager\ServiceManager */
$generator = $serviceManager->get(\Zend\Di\GodeGenerator\InjectorGenerator::class);
```

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [x] How will users use the new feature?
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
  - [x] Add a `CHANGELOG.md` entry for the new feature.
