### PR TITLE
Inject logger instance via constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /vendor/
 /zf-mkdoc-theme.tgz
 /zf-mkdoc-theme/
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 /vendor/
 /zf-mkdoc-theme.tgz
 /zf-mkdoc-theme/
-/.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#33](https://github.com/zendframework/zend-di/pull/32) add ability to pass
   `Psr\Log\LoggerInterface` to `Zend\Di\CodeGenerator\InjectorGenerator`'s constructor
 
-
-- [#32](https://github.com/zendframework/zend-di/pull/32) adds the implementation of
-  `Psr\Log\LoggerAwareInterface` to `Zend\Di\CodeGenerator\InjectorGenerator`
-
 - [#31](https://github.com/zendframework/zend-di/pull/31) adds the service
   factory `Zend\Di\Container\GeneratorFactory` for creating a
   `Zend\Di\CodeGenerator\InjectorGenerator` instance with zend-servicemanager.
@@ -32,12 +28,13 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Removed
 
 - [#33](https://github.com/zendframework/zend-di/pull/32) removes the implementation of
-  `Psr\Log\LoggerAwareInterface` from `Zend\Di\CodeGenerator\InjectorGenerator`
+  `Psr\Log\LoggerAwareInterface` from `Zend\Di\CodeGenerator\InjectorGenerator` that
+  was introduced with [#32](https://github.com/zendframework/zend-di/pull/32)
 
 ### Fixed
 
 - [#33](https://github.com/zendframework/zend-di/pull/32) fixes discouraged use of
-  `Psr\Log\LoggerAware*`
+  `Psr\Log\LoggerAware*` that was introduced with [#32](https://github.com/zendframework/zend-di/pull/32)
 
 ## 3.0.1 - TBD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing
+- Nothing.
 
 ### Fixed
 
-- Nothing
+- Nothing.
 
 ## 3.0.1 - TBD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- [#33](https://github.com/zendframework/zend-di/pull/32) add ability to pass
-  `Psr\Log\LoggerInterface` to `Zend\Di\CodeGenerator\InjectorGenerator`'s constructor
+- [#34](https://github.com/zendframework/zend-di/pull/34) adds ability to pass
+  `Psr\Log\LoggerInterface` to `Zend\Di\CodeGenerator\InjectorGenerator`'s constructor 
+  (e.g. `new InjectorGenerator($config, $resolver, $namespace, $logger)`)
 
 - [#31](https://github.com/zendframework/zend-di/pull/31) adds the service
   factory `Zend\Di\Container\GeneratorFactory` for creating a
@@ -27,14 +28,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- [#33](https://github.com/zendframework/zend-di/pull/32) removes the implementation of
-  `Psr\Log\LoggerAwareInterface` from `Zend\Di\CodeGenerator\InjectorGenerator` that
-  was introduced with [#32](https://github.com/zendframework/zend-di/pull/32)
+- Nothing
 
 ### Fixed
 
-- [#33](https://github.com/zendframework/zend-di/pull/32) fixes discouraged use of
-  `Psr\Log\LoggerAware*` that was introduced with [#32](https://github.com/zendframework/zend-di/pull/32)
+- Nothing
 
 ## 3.0.1 - TBD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#33](https://github.com/zendframework/zend-di/pull/32) add ability to pass
+  `Psr\Log\LoggerInterface` to `Zend\Di\CodeGenerator\InjectorGenerator`'s constructor
+
+
 - [#32](https://github.com/zendframework/zend-di/pull/32) adds the implementation of
   `Psr\Log\LoggerAwareInterface` to `Zend\Di\CodeGenerator\InjectorGenerator`
 
@@ -27,11 +31,13 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- [#33](https://github.com/zendframework/zend-di/pull/32) removes the implementation of
+  `Psr\Log\LoggerAwareInterface` from `Zend\Di\CodeGenerator\InjectorGenerator`
 
 ### Fixed
 
-- Nothing.
+- [#33](https://github.com/zendframework/zend-di/pull/32) fixes discouraged use of
+  `Psr\Log\LoggerAware*`
 
 ## 3.0.1 - TBD
 

--- a/docs/book/codegen.md
+++ b/docs/book/codegen.md
@@ -90,8 +90,8 @@ return [
 
 ## Logging
 
-The `InjectorGenerator` implements the PSR-3 [`LoggerAwareInterface`](http://www.php-fig.org/psr/psr-3/#4-psrlogloggerawareinterface).
-So you can pass any PSR-3 logger to its `setLogger()` method.
+The `InjectorGenerator` allows to pass a [PSR-3 logger](http://www.php-fig.org/psr/psr-3/) as optional 
+fourth construction parameter.
 
 The generator will log the following information:
 

--- a/docs/book/codegen.md
+++ b/docs/book/codegen.md
@@ -90,8 +90,8 @@ return [
 
 ## Logging
 
-The `InjectorGenerator` allows to pass a [PSR-3 logger](http://www.php-fig.org/psr/psr-3/) as optional 
-fourth construction parameter.
+The `InjectorGenerator` allows passing a [PSR-3 logger](http://www.php-fig.org/psr/psr-3/) instance
+via an optional fourth constructor parameter.
 
 The generator will log the following information:
 

--- a/src/CodeGenerator/GeneratorTrait.php
+++ b/src/CodeGenerator/GeneratorTrait.php
@@ -7,7 +7,6 @@
 
 namespace Zend\Di\CodeGenerator;
 
-use Psr\Log\LoggerAwareTrait;
 use Zend\Di\Exception\GenerateCodeException;
 use Zend\Di\Exception\LogicException;
 
@@ -16,8 +15,6 @@ use Zend\Di\Exception\LogicException;
  */
 trait GeneratorTrait
 {
-    use LoggerAwareTrait;
-
     /**
      * @var int
      */

--- a/src/CodeGenerator/InjectorGenerator.php
+++ b/src/CodeGenerator/InjectorGenerator.php
@@ -71,9 +71,9 @@ class InjectorGenerator
      *
      * @param ConfigInterface $config The configuration to compile from
      * @param DependencyResolverInterface $resolver The resolver to utilize
-     * @param string $namespace Namespace to use for generated class; defaults
+     * @param string|null $namespace Namespace to use for generated class; defaults
      *     to Zend\Di\Generated.
-     * @param LoggerInterface $logger An optional logger instance to log failures
+     * @param LoggerInterface|null $logger An optional logger instance to log failures
      *     and processed classes.
      */
     public function __construct(

--- a/src/CodeGenerator/InjectorGenerator.php
+++ b/src/CodeGenerator/InjectorGenerator.php
@@ -79,7 +79,7 @@ class InjectorGenerator
     public function __construct(
         ConfigInterface $config,
         DependencyResolverInterface $resolver,
-        ?string $namespace = null,
+        string $namespace = null,
         LoggerInterface $logger = null
     ) {
         $this->config = $config;

--- a/src/CodeGenerator/InjectorGenerator.php
+++ b/src/CodeGenerator/InjectorGenerator.php
@@ -8,6 +8,7 @@
 namespace Zend\Di\CodeGenerator;
 
 use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
 use Zend\Code\Generator\ClassGenerator;
@@ -25,7 +26,7 @@ use Zend\Di\Resolver\DependencyResolverInterface;
  * type, if available. This factory will contained pre-resolved dependencies
  * from the provided configuration, definition and resolver instances.
  */
-class InjectorGenerator implements LoggerAwareInterface
+class InjectorGenerator
 {
     use GeneratorTrait;
 
@@ -61,24 +62,32 @@ class InjectorGenerator implements LoggerAwareInterface
     private $autoloadGenerator;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * Constructs the compiler instance
      *
      * @param ConfigInterface $config The configuration to compile from
      * @param DependencyResolverInterface $resolver The resolver to utilize
      * @param string $namespace Namespace to use for generated class; defaults
      *     to Zend\Di\Generated.
+     * @param LoggerInterface $logger An optional logger instance to log failures
+     *     and processed classes.
      */
     public function __construct(
         ConfigInterface $config,
         DependencyResolverInterface $resolver,
-        ?string $namespace = null
+        ?string $namespace = null,
+        LoggerInterface $logger = null
     ) {
         $this->config = $config;
         $this->resolver = $resolver;
         $this->namespace = $namespace ? : 'Zend\Di\Generated';
         $this->factoryGenerator = new FactoryGenerator($config, $resolver, $this->namespace . '\Factory');
         $this->autoloadGenerator = new AutoloadGenerator($this->namespace);
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**

--- a/test/CodeGenerator/InjectorGeneratorTest.php
+++ b/test/CodeGenerator/InjectorGeneratorTest.php
@@ -74,11 +74,10 @@ class InjectorGeneratorTest extends TestCase
     {
         $config = new Config();
         $resolver = new DependencyResolver(new RuntimeDefinition(), $config);
-        $generator = new InjectorGenerator($config, $resolver);
         $logger = $this->prophesize(LoggerInterface::class);
 
+        $generator = new InjectorGenerator($config, $resolver, null, $logger->reveal());
         $generator->setOutputDirectory($this->dir);
-        $generator->setLogger($logger->reveal());
         $generator->generate([
             TestAsset\B::class
         ]);
@@ -90,11 +89,10 @@ class InjectorGeneratorTest extends TestCase
     {
         $config = new Config();
         $resolver = new DependencyResolver(new RuntimeDefinition(), $config);
-        $generator = new InjectorGenerator($config, $resolver);
         $logger = $this->prophesize(LoggerInterface::class);
+        $generator = new InjectorGenerator($config, $resolver, null, $logger->reveal());
 
         $generator->setOutputDirectory($this->dir);
-        $generator->setLogger($logger->reveal());
         $generator->generate([
             'Bad.And.Undefined.ClassName'
         ]);


### PR DESCRIPTION
PR #32 introduces logging capabilities by the use of an "Aware" interface (`LoggerAwareInterface` of PSR-3). This is discouraged in ZF.

This pull request changes it to constructor injection and removes the introduced usage of *Aware*.

Since this fixes a violation that only exists in the develop branch, this PR is targeted against develop instead of master.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

- [x] Is this related to quality assurance?
  As stated by @Ocramius in PR #32, the usage of aware-interfaces are discouraged throughout the Framework

