### PR TITLE
Improve migration with zend-servicemanager-di

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "zendframework/zend-servicemanager": "^3.0"
     },
     "conflict": {
-        "zendframework/zend-servicemanager-di": "*"
+        "zendframework/zend-servicemanager-di": "<3.0"
     },
     "suggest": {
         "zendframework/zend-servicemanager": "An IoC container without auto wiring capabilities",


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

ZF is aiming to allow easy migrations to new component versions whenever possible. For zend-di there is a component that integrated version 2 into zend-servicemanager.
Version 3 introduced a conflict-entry in it's composer.json, that states clearly zend-servicemanager-di is no longer needed. But it will also urge consumers to potentially upgrade many parts of their application.

To make life easier for these users, we should provide a new version for zend-servicemanager-di, that will deprecate it's own usage but allowing the user's to remove it's parts step by step.

*This PR requires changes in [zend-servicemanager-di] and must not be merged without them.*

I'll open a discussion about this in discourse about this issue. If the suggested changes to zend-servicemanager-di will be rejected by the framework group, this PR will be rejected as well.

Edit: [Link to the discourse topic](https://discourse.zendframework.com/t/rfc-changes-to-zend-servicemanager-di/441)

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [x] Is this related to quality assurance?
  Improves version migration (see above)