### PR TITLE
Mistake in the composer command in the documentation

### DIFF
--- a/docs/book/quick-start.md
+++ b/docs/book/quick-start.md
@@ -13,7 +13,7 @@ If you haven't already, [install Composer](https://getcomposer.org/).
 Once you have, you can install zend-di:
 
 ```bash
-$ composer install zendframework/zend-di
+$ composer require zendframework/zend-di
 ```
 
 ## 2. Configuring the injector


### PR DESCRIPTION
In the documentation for the zend-di section of the Quick Start, item 1 Installation (https://docs.zendframework.com/zend-di/quick-start/#1-installation), an mistake was made in the example commands for installing the module.

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [X] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
