### PR TITLE
Do not check the type of parameter for string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#49](https://github.com/zendframework/zend-di/pull/49) removes checking type of
+  class/interface typehinted parameter.
 
 ## 3.1.0 - 2018-10-23
 

--- a/src/Resolver/DependencyResolver.php
+++ b/src/Resolver/DependencyResolver.php
@@ -242,7 +242,7 @@ class DependencyResolver implements DependencyResolverInterface
         }
 
         if (is_string($value) && ! $this->isBuiltinType($requiredType)) {
-            return $this->isUsableType($value, $requiredType) ? new TypeInjection($value) : null;
+            return new TypeInjection($value);
         }
 
         // Classes may implement iterable

--- a/test/Resolver/DependencyResolverTest.php
+++ b/test/Resolver/DependencyResolverTest.php
@@ -622,4 +622,22 @@ class DependencyResolverTest extends TestCase
             $resolver->resolvePreference(TestAsset\B::class, TestAsset\Hierarchy\C::class)
         );
     }
+
+    public function testParametresResolverShouldNotCheckTheTypeForString()
+    {
+        $definition = new RuntimeDefinition();
+        $config = new Config();
+        $config->setParameters(
+            TestAsset\B::class,
+            ['a' => 'my-service']
+        );
+
+        $resolver = new DependencyResolver($definition, $config);
+
+        $parameters = $resolver->resolveParameters(TestAsset\B::class);
+
+        $this->assertCount(1, $parameters);
+        $this->assertInstanceOf(TypeInjection::class, $parameters['a']);
+        $this->assertSame('my-service', $parameters['a']->__toString());
+    }
 }


### PR DESCRIPTION
## Issue description

Please consider the following configuration:
```php
'service-manager' => [
    'factories' => [
        'my-service.config' => MyServiceConfigFactory::class,
    ],
],
'dependencies' => [
    'auto' => [
        'types' => [
            MyController::class => [
                'parameters' => [
                    'config' => 'my-service.config',
                ],
            ],
        ],
    ],
],
```

where `MyController` is as follows:

```php
class MyController
{
    public function __construct(Config $config) {}
}
```

according to the documentation
> An IoC container service name as string: This is only possible if the required type is a class or interface. For other types (scalars, `iterable`, `callable`, etc) or typeless parameters, the string value is passed **as is**.
(see: https://docs.zendframework.com/zend-di/config/#parameters)

it should work correctly, so we should have generated factory for `MyController`:

```php
class MyControllerFactory
{
    public function __invoke(ContainerInterface $container)
    {
        return new MyController($container->get('my-service.config'));
    }
}
```

but unfortunately parameter resolver try to check the type.
If we add:
```php
`dependencies` => [
    `auto` => [
        `types` => [
            'my-service.config' => [
                'typeOf' => Config::class,
            ],
        ],
    ],
],
```

then the factory for `MyController` is as expected but unfortunately also factory for `my-service.config` is created and replaced with the one configured in `service-manager`.

The correct result we can get if we have:

```php
'dependencies' => [
    'auto' => [
        'types' => [
            MyController::class => [
                'parameters' => [
                    'config' => new Zend\Di\Resolver\TypeInjection('my-service.config'),
                ],
            ],
        ],
    ],
],
```

but this is not ideal (new instances in the static configuration).

## Solution

We don't need to check type if typehint is class/interface and configuration is string.

- [X] Are you fixing a bug?
  - [X] Detail how the bug is invoked currently.
  - [X] Detail the original, incorrect behavior.
  - [X] Detail the new, expected behavior.
  - [X] Base your feature on the `master` branch, and submit against that branch.
  - [X] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.
