### PR TITLE
Updated ValueInjection to check array values as these can be exportable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#50](https://github.com/zendframework/zend-di/pull/50) fixes recognizing array values
+  as exportable, so factories can be generated for default array values.
 
 ## 3.1.0 - 2018-10-23
 

--- a/src/Resolver/ValueInjection.php
+++ b/src/Resolver/ValueInjection.php
@@ -82,7 +82,6 @@ class ValueInjection implements InjectionInterface
      * For arrays it uses recursion.
      *
      * @param mixed $value
-     * @return bool
      */
     private function isExportableRecursive($value) : bool
     {

--- a/src/Resolver/ValueInjection.php
+++ b/src/Resolver/ValueInjection.php
@@ -8,10 +8,16 @@
 namespace Zend\Di\Resolver;
 
 use Psr\Container\ContainerInterface;
-use ReflectionObject;
+use ReflectionMethod;
 use Zend\Di\Exception\LogicException;
 
+use function is_array;
+use function is_object;
+use function is_scalar;
+use function method_exists;
 use function trigger_error;
+use function var_export;
+
 use const E_USER_DEPRECATED;
 
 /**
@@ -68,15 +74,36 @@ class ValueInjection implements InjectionInterface
      */
     public function isExportable() : bool
     {
-        if (is_scalar($this->value) || ($this->value === null)) {
+        return $this->isExportableRecursive($this->value);
+    }
+
+    /**
+     * Check if the provided value is exportable.
+     * For arrays it uses recursion.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    private function isExportableRecursive($value) : bool
+    {
+        if (is_scalar($value) || $value === null) {
             return true;
         }
 
-        if (is_object($this->value) && method_exists($this->value, '__set_state')) {
-            $reflection = new ReflectionObject($this->value);
-            $method = $reflection->getMethod('__set_state');
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                if (! $this->isExportableRecursive($item)) {
+                    return false;
+                }
+            }
 
-            return ($method->isStatic() && $method->isPublic());
+            return true;
+        }
+
+        if (is_object($value) && method_exists($value, '__set_state')) {
+            $method = new ReflectionMethod($value, '__set_state');
+
+            return $method->isStatic() && $method->isPublic();
         }
 
         return false;

--- a/test/Resolver/ValueInjectionTest.php
+++ b/test/Resolver/ValueInjectionTest.php
@@ -98,6 +98,23 @@ class ValueInjectionTest extends TestCase
             'null'         => [null],
             'float'        => [microtime(true)],
             'object'       => [new TestAsset\Resolver\ExportableValue()],
+            'array'        => [[]],
+            'array-string' => [['TestValue', 'OtherValue']],
+            'array-int'    => [[123, 456]],
+            'array-mixed'  => [
+                [
+                    new TestAsset\Resolver\ExportableValue(),
+                    [1],
+                    null,
+                    false,
+                    true,
+                    time(),
+                    microtime(true),
+                    [[], []],
+                    uniqid(),
+                    [],
+                ],
+            ],
         ];
     }
 
@@ -111,6 +128,8 @@ class ValueInjectionTest extends TestCase
             'stream'          => [$this->streamFixture],
             'noSetState'      => [new TestAsset\Resolver\UnexportableValue1()],
             'privateSetState' => [new TestAsset\Resolver\UnexportableValue2()],
+            'arrayNoSetState' => [[new TestAsset\Resolver\UnexportableValue1()]],
+            'arrayPrivateSetState' => [[new TestAsset\Resolver\UnexportableValue2()]],
         ];
     }
 


### PR DESCRIPTION
Extracted logic from isExportable function to private function and use recursion for arrays.

Because array values (especially empty array values) were not recognised as exportable factories for classes with empty array as default value for param were not created.

- [X] Are you fixing a bug?
  - [X] Detail how the bug is invoked currently.
  - [X] Detail the original, incorrect behavior.
  - [X] Detail the new, expected behavior.
  - [X] Base your feature on the `master` branch, and submit against that branch.
  - [X] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.
