### PR TITLE
Updated CHANGELOG entry for #48 - develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- [#48](https://github.com/zendframework/zend-di/pull/48) removes support for zend-stdlib v2 releases.
 
 ### Fixed
 


### PR DESCRIPTION
As of #48 we removed support for zend-stdlib v2 releases. It should be noted in the CHANGELOG.

In this PR I am adding the missing entry.

- [X] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->