### PR TITLE
Add tests to ensure preference fallback behavior

### DIFF
--- a/test/Resolver/DependencyResolverTest.php
+++ b/test/Resolver/DependencyResolverTest.php
@@ -646,7 +646,7 @@ class DependencyResolverTest extends TestCase
      *
      * @see https://docs.zendframework.com/zend-di/config/#type-preferences
      */
-    public function testResolvePreferenceFallsBackToGlobalPreferenceWhenNotSuitableForRequirement()
+    public function testResolvePreferenceFallsBackToGlobalPreferenceWhenNotSuitableForClassRequirement()
     {
         $definition = new RuntimeDefinition();
         $config = new Config();
@@ -665,7 +665,7 @@ class DependencyResolverTest extends TestCase
      *
      * @see https://docs.zendframework.com/zend-di/config/#type-preferences
      */
-    public function testResolvePreferenceReturnsNullWhenNothingIsSuitableForRequirement()
+    public function testResolvePreferenceReturnsNullWhenNothingIsSuitableForClassRequirement()
     {
         $definition = new RuntimeDefinition();
         $config = new Config();
@@ -674,5 +674,53 @@ class DependencyResolverTest extends TestCase
         $resolver = new DependencyResolver($definition, $config);
 
         $this->assertNull($resolver->resolvePreference(TestAsset\A::class, TestAsset\RequiresA::class));
+    }
+
+    /**
+     * Ensures the documented preference resolver behavior as documented
+     *
+     * @see https://docs.zendframework.com/zend-di/config/#type-preferences
+     */
+    public function testResolvePreferenceFallsBackToGlobalPreferenceWhenNotSuitableForInterfaceRequirement()
+    {
+        $definition = new RuntimeDefinition();
+        $config = new Config();
+        $config->setTypePreference(
+            TestAsset\Hierarchy\InterfaceB::class,
+            TestAsset\Hierarchy\InterfaceA::class,
+            TestAsset\A::class
+        );
+        $config->setTypePreference(TestAsset\Hierarchy\InterfaceB::class, TestAsset\Hierarchy\InterfaceC::class);
+        $resolver = new DependencyResolver($definition, $config);
+
+        $this->assertSame(
+            TestAsset\Hierarchy\InterfaceC::class,
+            $resolver->resolvePreference(TestAsset\Hierarchy\InterfaceB::class, TestAsset\A::class)
+        );
+    }
+
+    /**
+     * Ensures the documented preference resolver behavior as documented
+     *
+     * @see https://docs.zendframework.com/zend-di/config/#type-preferences
+     */
+    public function testResolvePreferenceReturnsNullWhenNothingIsSuitableForInterfaceRequirement()
+    {
+        $definition = new RuntimeDefinition();
+        $config = new Config();
+        $config->setTypePreference(
+            TestAsset\Hierarchy\InterfaceB::class,
+            TestAsset\B::class,
+            TestAsset\A::class
+        );
+        $config->setTypePreference(
+            TestAsset\Hierarchy\InterfaceB::class,
+            TestAsset\Hierarchy\InterfaceA::class
+        );
+        $resolver = new DependencyResolver($definition, $config);
+
+        $this->assertNull(
+            $resolver->resolvePreference(TestAsset\Hierarchy\InterfaceB::class, TestAsset\A::class)
+        );
     }
 }

--- a/test/Resolver/DependencyResolverTest.php
+++ b/test/Resolver/DependencyResolverTest.php
@@ -723,4 +723,21 @@ class DependencyResolverTest extends TestCase
             $resolver->resolvePreference(TestAsset\Hierarchy\InterfaceB::class, TestAsset\A::class)
         );
     }
+
+    public function testResolvePreferenceUsesDefinedClassForInterfaceRequirements()
+    {
+        $definition = new RuntimeDefinition();
+        $config = new Config();
+        $config->setTypePreference(
+            TestAsset\Hierarchy\InterfaceB::class,
+            TestAsset\Hierarchy\B::class
+        );
+
+        $resolver = new DependencyResolver($definition, $config);
+
+        $this->assertSame(
+            TestAsset\Hierarchy\B::class,
+            $resolver->resolvePreference(TestAsset\Hierarchy\InterfaceB::class, TestAsset\A::class)
+        );
+    }
 }

--- a/test/Resolver/DependencyResolverTest.php
+++ b/test/Resolver/DependencyResolverTest.php
@@ -640,4 +640,39 @@ class DependencyResolverTest extends TestCase
         $this->assertInstanceOf(TypeInjection::class, $parameters['a']);
         $this->assertSame('my-service', $parameters['a']->__toString());
     }
+
+    /**
+     * Ensures the documented preference resolver behavior as documented
+     *
+     * @see https://docs.zendframework.com/zend-di/config/#type-preferences
+     */
+    public function testResolvePreferenceFallsBackToGlobalPreferenceWhenNotSuitableForRequirement()
+    {
+        $definition = new RuntimeDefinition();
+        $config = new Config();
+        $config->setTypePreference(TestAsset\A::class, TestAsset\B::class, TestAsset\RequiresA::class);
+        $config->setTypePreference(TestAsset\A::class, TestAsset\ExtendedA::class);
+        $resolver = new DependencyResolver($definition, $config);
+
+        $this->assertSame(
+            TestAsset\ExtendedA::class,
+            $resolver->resolvePreference(TestAsset\A::class, TestAsset\RequiresA::class)
+        );
+    }
+
+    /**
+     * Ensures the documented preference resolver behavior as documented
+     *
+     * @see https://docs.zendframework.com/zend-di/config/#type-preferences
+     */
+    public function testResolvePreferenceReturnsNullWhenNothingIsSuitableForRequirement()
+    {
+        $definition = new RuntimeDefinition();
+        $config = new Config();
+        $config->setTypePreference(TestAsset\A::class, TestAsset\ExtendedB::class, TestAsset\RequiresA::class);
+        $config->setTypePreference(TestAsset\A::class, TestAsset\B::class);
+        $resolver = new DependencyResolver($definition, $config);
+
+        $this->assertNull($resolver->resolvePreference(TestAsset\A::class, TestAsset\RequiresA::class));
+    }
 }

--- a/test/TestAsset/ExtendedA.php
+++ b/test/TestAsset/ExtendedA.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-di for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-di/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Di\TestAsset;
+
+class ExtendedA extends A
+{
+}


### PR DESCRIPTION
These tests ensure compliance to the documentation. PR #49 revealed
the lack of this test.

See https://docs.zendframework.com/zend-di/config/#type-preferences

Provide a narrative description of what you are trying to accomplish:

- [x] Is this related to quality assurance?
- [x] Is this related to documentation?
